### PR TITLE
Add Meetup date finder function and instructions

### DIFF
--- a/meetup/README.md
+++ b/meetup/README.md
@@ -1,0 +1,66 @@
+# Meetup
+
+Welcome to Meetup on Exercism's AWK Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Recurring monthly meetups are generally scheduled on the given weekday of a given week each month.
+In this exercise you will be given the recurring schedule, along with a month and year, and then asked to find the exact date of the meetup.
+
+For example a meetup might be scheduled on the _first Monday_ of every month.
+You might then be asked to find the date that this meetup will happen in January 2018.
+In other words, you need to determine the date of the first Monday of January 2018.
+
+Similarly, you might be asked to find:
+
+- the third Tuesday of August 2019 (August 20, 2019)
+- the teenth Wednesday of May 2020 (May 13, 2020)
+- the fourth Sunday of July 2021 (July 25, 2021)
+- the last Thursday of November 2022 (November 24, 2022)
+
+The descriptors you are expected to process are: `first`, `second`, `third`, `fourth`, `last`, `teenth`.
+
+Note that descriptor `teenth` is a made-up word.
+
+It refers to the seven numbers that end in '-teen' in English: 13, 14, 15, 16, 17, 18, and 19.
+But general descriptions of dates use ordinal numbers, e.g. the _first_ Monday, the _third_ Tuesday.
+
+For the numbers ending in '-teen', that becomes:
+
+- 13th (thirteenth)
+- 14th (fourteenth)
+- 15th (fifteenth)
+- 16th (sixteenth)
+- 17th (seventeenth)
+- 18th (eighteenth)
+- 19th (nineteenth)
+
+So there are seven numbers ending in '-teen'.
+And there are also seven weekdays (Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday).
+Therefore, it is guaranteed that each day of the week (Monday, Tuesday, ...) will have exactly one numbered day ending with "teen" each month.
+
+If asked to find the teenth Saturday of August, 1953 (or, alternately the "Saturteenth" of August, 1953), we need to look at the calendar for August 1953:
+
+```plaintext
+    August 1953
+Su Mo Tu We Th Fr Sa
+                   1
+ 2  3  4  5  6  7  8
+ 9 10 11 12 13 14 15
+16 17 18 19 20 21 22
+23 24 25 26 27 28 29
+30 31
+```
+
+The Saturday that has a number ending in '-teen' is August 15, 1953.
+
+## Source
+
+### Created by
+
+- @glennj
+
+### Based on
+
+Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month

--- a/meetup/meetup.pq
+++ b/meetup/meetup.pq
@@ -1,0 +1,33 @@
+let
+    LastDayOfMonth = (year as number, month as number) as number =>
+        let
+            date = #date(year, month, 1),
+            nextMonth = Date.AddMonths(date, 1),
+            lastDay = Date.AddDays(nextMonth, -1),
+            day = Date.Day(lastDay)
+        in
+            day,
+    FindDate = (startDate as date, dayOfWeek as text) as date =>
+        let
+            dates = List.Transform({-6..0}, each Date.AddDays(startDate, -_))
+        in
+            List.Select(dates, each Date.DayOfWeekName(_, "en-US") = dayOfWeek){0},
+    Solution = (year as number, month as number, week as text, dayOfWeek as text) as date =>
+        let
+            day =
+                if week = "first" then
+                    1
+                else if week = "second" then
+                    8
+                else if week = "third" then
+                    15
+                else if week = "fourth" then
+                    22
+                else if week = "teenth" then
+                    13
+                else
+                    LastDayOfMonth(year, month) - 6
+        in
+            FindDate(#date(year, month, day), dayOfWeek)
+in
+    Solution

--- a/meetup/test-meetup.pq
+++ b/meetup/test-meetup.pq
@@ -1,0 +1,17 @@
+let
+    Source = TestCasesOne("meetup"),
+    Parameters = Table.ExpandRecordColumn(Source, "input", {"year", "month", "week", "dayofweek"}),
+    TypedParameters = Table.TransformColumnTypes(
+        Parameters,
+        {
+            {"year", Int64.Type},
+            {"month", Int64.Type},
+            {"week", type text},
+            {"dayofweek", type text},
+            {"expected", type date}
+        }
+    ),
+    Actual = Table.AddColumn(TypedParameters, "actual", each Meetup([year], [month], [week], [dayofweek]), type date),
+    TestResults = Table.AddColumn(Actual, "passed", each [expected] = [actual])
+in
+    TestResults


### PR DESCRIPTION
This commit introduces a new problem, the meetup date finder function. The file `meetup.pq` implements a function to find the exact meetup date given a month, year, and recurring schedule. Additionally, a `README.md` provides detailed problem instructions. These additions provide an opportunity for learners to practice dealing with dates and conditional logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality to calculate the date of recurring meetups within a month using descriptors like `first`, `second`, `third`, `fourth`, `last`, and `teenth`.
	- Added capabilities to determine the last day of a month and find a specific weekday within a given week.
	- Introduced a test scenario for meetup functions to validate the calculated meetup dates against expected dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->