### PR TITLE
Add 'leap year' solution and update test cases

### DIFF
--- a/leap/ideomatic-solution-leap.pq
+++ b/leap/ideomatic-solution-leap.pq
@@ -1,0 +1,4 @@
+/*
+    Determine whether a given year is a leap year.
+*/
+(year as number) as logical => Date.IsLeapYear(#date(year, 1, 1))

--- a/leap/solution-leap.pq
+++ b/leap/solution-leap.pq
@@ -1,0 +1,8 @@
+/*
+    Determine whether a given year is a leap year.
+*/
+let
+    Solution = (year as number) as logical =>
+        Number.Mod(year, 4) = 0 and (Number.Mod(year, 100) <> 0 or Number.Mod(year, 400) = 0)
+in
+    Solution

--- a/leap/template-leap.pq
+++ b/leap/template-leap.pq
@@ -1,0 +1,8 @@
+/*
+    Determine whether a given year is a leap year.
+*/
+let 
+    Solution = (year as number) as logical => 
+        error "Delete this statement and write your own implementation." 
+in 
+    Solution

--- a/leap/test-leap.pq
+++ b/leap/test-leap.pq
@@ -1,0 +1,7 @@
+let
+  Source = ExerciseTestCases("leap"),
+  Input = Table.ExpandRecordColumn(Source, "input", {"year"}, {"year"}),
+  Actual = Table.TransformColumnTypes(Table.AddColumn(Input, "actual", each #"Solution Leap"([year])), {{"actual", type logical}}),
+  Result = Table.TransformColumnTypes(Table.AddColumn(Actual, "passed", each [expected]=[actual]), {{"passed", type logical}})
+in
+  Result

--- a/test-cases/ExerciseTestCases.pq
+++ b/test-cases/ExerciseTestCases.pq
@@ -1,0 +1,30 @@
+let
+    exercisesUrl = "https://raw.githubusercontent.com/exercism/problem-specifications/main/exercises",
+    canonicalData = "canonical-data.json",
+    Source = (exercise as text) as table =>
+        let
+            uri = exercisesUrl & "/" & exercise & "/" & canonicalData,
+            content = Web.Contents(uri),
+            jsonDoc = Json.Document(content),
+            cases = jsonDoc[cases],
+            twoLevels = Record.FieldCount(cases{0}) = 2,
+            TestData = Table.FromList(cases, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
+            TestCases =
+                if twoLevels then
+                    let
+                        TestSuits = Table.ExpandRecordColumn(
+                            TestData, "Column1", {"description", "cases"}, {"category", "cases"}
+                        ),
+                        TestCases = Table.ExpandListColumn(TestSuits, "cases")
+                    in
+                        Table.ExpandRecordColumn(
+                            TestCases, "cases", {"uuid", "description", "property", "input", "expected"}
+                        )
+                else
+                    Table.ExpandRecordColumn(
+                        TestData, "Column1", {"uuid", "description", "property", "input", "expected"}
+                    )
+        in
+            TestCases
+in
+    Source

--- a/test-cases/TestCasesOne.pq
+++ b/test-cases/TestCasesOne.pq
@@ -8,6 +8,7 @@ let
             jsonDoc = Json.Document(content),
             cases = jsonDoc[cases],
             TestData = Table.FromList(cases, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
+            
             TestCases = Table.ExpandRecordColumn(
                 TestData,
                 "Column1",

--- a/test-cases/TestCasesTwo.pq
+++ b/test-cases/TestCasesTwo.pq
@@ -8,6 +8,7 @@ let
             jsonDoc = Json.Document(content),
             cases = jsonDoc[cases],
             TestData = Table.FromList(cases, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
+            // Two
             TestSuits = Table.ExpandRecordColumn(
                 TestData, "Column1", {"description", "cases"}, {"description", "cases"}
             ),


### PR DESCRIPTION
Implemented a solution to determine whether a given year is leap year or not in Power Query. Three versions of the solution are added: solution-leap.pq, ideomatic-solution-leap.pq, and template-leap.pq. Added test-leap.pq for testing these solutions and updated ExerciseTestCases.pq to fetch exercise data. Existing test cases TestCasesOne.pq and TestCasesTwo.pq have also been modified to cater these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a function to determine whether a given year is a leap year across multiple files.
	- Added a new test case for the leap year functionality.
	- Implemented a function to retrieve and format test cases for exercises from a specified URL.

- **Refactor**
	- Improved code readability in test cases files by adding a blank line and a comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->